### PR TITLE
- fix queue worker state after deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -23,3 +23,6 @@ docker-compose -f $FILE exec -T app php artisan migrate --force &&
     docker-compose -f $FILE exec -T app php artisan config:cache &&
     docker-compose -f $FILE exec -T app php artisan route:cache &&
     docker-compose -f $FILE exec -T app php artisan view:cache
+
+echo "Restart app container"
+docker-compose -f $FILE restart app


### PR DESCRIPTION
This PR fixes queue worker state after deployment.

Issue:
After new deployment queue worker is not restarted so it keeps old app state.
`deploy.sh` script does not restart docker compose stack after deployment.

https://laravel.com/docs/10.x/queues#queue-workers-and-deployment:
```
Since queue workers are long-lived processes, they will not notice changes to your code without being restarted.
```
